### PR TITLE
feat: add 'legal' as a task cluster pattern

### DIFF
--- a/hermes_hud/collectors/patterns.py
+++ b/hermes_hud/collectors/patterns.py
@@ -14,6 +14,7 @@ from .utils import default_hermes_dir, parse_timestamp, safe_get
 # First match wins
 _CLUSTERS = [
     ("git ops",    ["commit", "push", "pull", "merge", "branch", "rebase", " pr ", "pull request", "release", "tag", "stash"]),
+    ("legal",      ["affidavit", "exhibit", "pleading", "brief", "court", "filing", "cpr", "defendant", "claimant", "injunction", "discovery", "deposition", "ecsc", "application notice", "witness statement", "costs"]),
     ("debugging",  ["fix", "bug", "error", "broken", "failing", "crash", "traceback", "exception", "not work", "doesn't work"]),
     ("code gen",   ["create", "implement", "add feature", "build", "write a", "new function", "new class", "generate"]),
     ("refactor",   ["refactor", "rename", "clean up", "simplify", "extract", "reorganize", "restructure", "move"]),


### PR DESCRIPTION
Adds a `legal` category to the prompt pattern classifier.

With the current classifier, 'other' is the largest category at ~30% of sessions. The new `legal` cluster captures litigation-related sessions (affidavits, exhibits, court filings, ECSC, etc.) that currently fall through to 'other'.

Keywords matched (case-insensitive):
- affidavit, exhibit, pleading, brief, court, filing
- cpr, defendant, claimant, injunction, discovery, deposition
- ecsc, application notice, witness statement, costs

Placed after 'git ops' so it matches before 'other'.

Closes #11.