### PR TITLE
fix: replace os.system('clear') with ANSI escape code

### DIFF
--- a/hermes_hud/neofetch_ai.py
+++ b/hermes_hud/neofetch_ai.py
@@ -1,7 +1,6 @@
 """AI awakening neofetch — something becoming aware of itself."""
 
 import sys
-import os
 import time
 import random
 import re
@@ -124,7 +123,7 @@ def raw_bar(pct, width=22):
 
 
 def main():
-    os.system('clear')
+    print("\033c", end="")
     d = collect_neofetch_data()
     state, health, projects, cron, corrections = d.state, d.health, d.projects, d.cron, d.corrections
     dr, days = d.dr, d.days

--- a/hermes_hud/neofetch_anime.py
+++ b/hermes_hud/neofetch_anime.py
@@ -1,6 +1,5 @@
 """Anime hacker girl neofetch for Hermes HUD."""
 
-import os
 import time
 
 from .neofetch_base import (
@@ -33,7 +32,7 @@ def kaomoji_bar(pct, width=20):
 
 
 def main():
-    os.system('clear')
+    print("\033c", end="")
     d = collect_neofetch_data()
     state, health, projects, cron, corrections = d.state, d.health, d.projects, d.cron, d.corrections
     dr, days = d.dr, d.days

--- a/hermes_hud/neofetch_br.py
+++ b/hermes_hud/neofetch_br.py
@@ -1,6 +1,5 @@
 """Blade Runner inspired neofetch for Hermes HUD."""
 
-import os
 import time
 
 from .neofetch_base import (
@@ -30,7 +29,7 @@ def bar(current, maximum, width=20):
 
 
 def main():
-    os.system('clear')
+    print("\033c", end="")
     d = collect_neofetch_data()
     state, health, projects, cron, corrections = d.state, d.health, d.projects, d.cron, d.corrections
     dr, days = d.dr, d.days

--- a/hermes_hud/neofetch_fsociety.py
+++ b/hermes_hud/neofetch_fsociety.py
@@ -1,6 +1,5 @@
 """fsociety x hermes neofetch — a collaboration."""
 
-import os
 import time
 import random
 
@@ -50,7 +49,7 @@ def raw_bar(pct, width=22):
 
 
 def main():
-    os.system('clear')
+    print("\033c", end="")
     d = collect_neofetch_data()
     state, health, projects, cron, corrections = d.state, d.health, d.projects, d.cron, d.corrections
     dr, days = d.dr, d.days


### PR DESCRIPTION
Replaces \`os.system('clear')\` with \`print("\033c", end="")\` in all 4 neofetch theme files.

This eliminates unnecessary shell subprocess invocation for a trivial terminal-clear operation, removes linter warnings (bandit B605), and is more portable.

**Changes:**
- \`hermes_hud/neofetch_ai.py\`
- \`hermes_hud/neofetch_anime.py\`
- \`hermes_hud/neofetch_br.py\`
- \`hermes_hud/neofetch_fsociety.py\`

Each file also had the now-unused \`import os\` removed.

Closes #7.