### PR TITLE
fix: replace custom YAML parser with yaml.safe_load

### DIFF
--- a/hermes_hud/collectors/profiles.py
+++ b/hermes_hud/collectors/profiles.py
@@ -6,6 +6,7 @@ import json
 import os
 import sqlite3
 import subprocess
+import yaml
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -20,37 +21,12 @@ from ..models import ProfileInfo, ProfilesState
 _ALIAS_BIN_DIRS = [os.path.expanduser("~/.local/bin"), "/usr/local/bin"]
 
 
-def _parse_yaml_simple(text: str) -> dict:
-    """Minimal YAML parser for config.yaml (flat + one level nested)."""
-    result = {}
-    current_key = None
-    for line in text.split("\n"):
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        # Nested key (indented)
-        if line.startswith("  ") and current_key and ":" in stripped:
-            k, _, v = stripped.partition(":")
-            v = v.strip().strip("'").strip('"')
-            if current_key not in result or not isinstance(result[current_key], dict):
-                result[current_key] = {}
-            if isinstance(result[current_key], dict):
-                result[current_key][k.strip()] = v
-        # List item
-        elif line.startswith("- ") and current_key:
-            if not isinstance(result.get(current_key), list):
-                result[current_key] = []
-            result[current_key].append(stripped.lstrip("- ").strip())
-        # Top-level key
-        elif ":" in stripped and not stripped.startswith("-"):
-            k, _, v = stripped.partition(":")
-            k = k.strip()
-            v = v.strip().strip("'").strip('"')
-            current_key = k
-            if v:
-                result[k] = v
-            # else: next lines will fill it (dict or list)
-    return result
+def _parse_yaml_safe(text: str) -> dict:
+    """Parse config.yaml using pyyaml.safe_load."""
+    result = yaml.safe_load(text)
+    if isinstance(result, dict):
+        return result
+    return {}
 
 
 def _read_config(profile_dir: Path) -> dict:
@@ -60,7 +36,7 @@ def _read_config(profile_dir: Path) -> dict:
         return {}
     try:
         text = config_path.read_text(encoding="utf-8")
-        return _parse_yaml_simple(text)
+        return _parse_yaml_safe(text)
     except Exception:
         return {}
 


### PR DESCRIPTION
### Problem
The profiles collector at `hermes_hud/collectors/profiles.py:23-53` uses a hand-rolled YAML parser (`_parse_yaml_simple`) that only supports flat keys and one level of nesting. This is fragile and silently mis-parses:

- Lists with nested dicts
- Multi-line strings
- Complex nesting beyond one level
- Values containing colons

### Why it matters
- `pyyaml` is already required in `pyproject.toml`
- Users could have config.yaml with structures the custom parser would silently break
- No error is raised on malformed parse -- just wrong data

### Fix
Replace `_parse_yaml_simple(text)` with `yaml.safe_load(text)`. Add a fallback to `{}` on parse error (same as today).

### Files affected
- `hermes_hud/collectors/profiles.py` (lines 23-53)
- Remove `_parse_yaml_simple()` entirely
