### PR TITLE
fix: replace manual dotenv cache with thread-safe lru_cache

### DIFF
--- a/hermes_hud/collectors/health.py
+++ b/hermes_hud/collectors/health.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import os
-
-from .utils import default_hermes_dir
 import subprocess
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
+
+from .utils import default_hermes_dir
 
 
 @dataclass
@@ -82,16 +83,9 @@ def _load_dotenv_keys(dotenv_path: str) -> set[str]:
     return keys
 
 
-# Cache for dotenv keys
-_dotenv_cache: set[str] | None = None
-
-
+@lru_cache(maxsize=1)
 def _get_dotenv_keys(hermes_dir: str) -> set[str]:
     """Get all key names from hermes .env files."""
-    global _dotenv_cache
-    if _dotenv_cache is not None:
-        return _dotenv_cache
-
     keys: set[str] = set()
     # Check multiple locations
     for env_path in [
@@ -99,7 +93,6 @@ def _get_dotenv_keys(hermes_dir: str) -> set[str]:
         os.path.expanduser("~/.env"),
     ]:
         keys.update(_load_dotenv_keys(env_path))
-    _dotenv_cache = keys
     return keys
 
 
@@ -193,9 +186,6 @@ def collect_health(hermes_dir: str | None = None) -> HealthState:
         pass
 
     # API keys
-    global _dotenv_cache
-    _dotenv_cache = None  # Reset cache on each collection
-
     known_names = {key_name for key_name, _, _ in EXPECTED_KEYS}
     for key_name, source, note in EXPECTED_KEYS:
         present = _check_env_key(key_name, hermes_dir)


### PR DESCRIPTION
### Problem
`hermes_hud/collectors/health.py:86-103` uses a global `_dotenv_cache` variable with no locking:

```python
_dotenv_cache: set[str] | None = None

def _get_dotenv_keys(hermes_dir: str) -> set[str]:
    global _dotenv_cache
    if _dotenv_cache is not None:
        return _dotenv_cache
    # ... populate ...
    _dotenv_cache = keys
    return _dotenv_cache
```

Meanwhile, `hermes_hud/collectors/agents.py` uses `ThreadPoolExecutor` for concurrent process scanning. If multiple threads call collectors concurrently, the global cache could experience race conditions (check-then-act pattern).

### Why it matters
- Thread safety issue on concurrent execution paths
- Could return partial or corrupted state under load

### Fix Options
1. Add `threading.Lock()` around the cache read/write
2. Remove the cache entirely -- file I/O for 2 small .env files is negligible for a TUI dashboard
3. Use `functools.lru_cache` which is thread-safe in Python 3.2+

### Files to modify
- `hermes_hud/collectors/health.py`
