### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[neofetch]"
+          pip install pytest
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/ -v


### PR DESCRIPTION
### Problem
The project has no GitHub Actions CI workflow. There's a Makefile with a `test` target and a comprehensive test suite, but nothing runs automatically on push or PR.

### What should happen
- Run `pytest tests/ -v` on push to `main` and PRs
- Test across Python 3.11, 3.12, 3.13 (as declared in pyproject.toml classifiers)
- Check that the package installs cleanly

### Suggested setup
Create `.github/workflows/ci.yml` with:
- Triggers on push to `main` and PRs
- Matrix: python-version [3.11, 3.12, 3.13]
- Steps: checkout, setup-python, pip install -e ".[neofetch]", pytest
