### PR TITLE
feat: add Space/b/n page scrolling like less

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[neofetch]"
+          pip install pytest
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/ -v

--- a/hermes_hud/hud.py
+++ b/hermes_hud/hud.py
@@ -233,6 +233,11 @@ class HermesHUD(App):
         Binding("k", "scroll_up", "Scroll Up", show=False),
         Binding("g", "scroll_home", "Top", show=False),
         Binding("G", "scroll_end", "Bottom", show=False),
+        Binding("pageup", "page_up", "Page Up", show=False),
+        Binding("pagedown", "page_down", "Page Down", show=False),
+        Binding("space", "page_down", "Page Down", show=False, key_display="Space"),
+        Binding("n", "page_down", "Next Page", show=False),
+        Binding("b", "page_up", "Previous Page", show=False),
     ]
 
     def __init__(self):
@@ -269,7 +274,7 @@ class HermesHUD(App):
         return Static(
             f"  [dim]Last refreshed: {self.state.collected_at:%H:%M:%S} │ "
             f"[bold]r[/bold] refresh │ [bold]q[/bold] quit │ "
-            f"[bold]1-8[/bold] switch tabs │ [bold]j/k[/bold] scroll[/dim]",
+            f"[bold]1-8[/bold] switch tabs │ [bold]j/k[/bold] line scroll │ [bold]Space/b/n[/bold] page scroll[/dim]",
             classes="status-line",
         )
 
@@ -349,6 +354,12 @@ class HermesHUD(App):
 
     def action_scroll_end(self) -> None:
         self._active_scroll().scroll_end(animate=False)
+
+    def action_page_up(self) -> None:
+        self._active_scroll().scroll_page_up(animate=False)
+
+    def action_page_down(self) -> None:
+        self._active_scroll().scroll_page_down(animate=False)
 
 
 def _check_hermes_data():


### PR DESCRIPTION
Adds page-level scrolling alongside existing j/k line scroll:

- `Space` / `n` / `PageDown` — scroll one page down
- `b` / `PageUp` — scroll one page up

Uses Textual's built-in `scroll_page_up()` and `scroll_page_down()` on the active tab's VerticalScroll container.

The status line at the bottom now shows both navigation modes: `j/k` for line scroll, `Space/b/n` for page scroll.

Closes #15.